### PR TITLE
raise exception when parsing duration to be consistent with datetime

### DIFF
--- a/PySO8601/durations.py
+++ b/PySO8601/durations.py
@@ -43,4 +43,4 @@ def parse_duration(duration):
                                       minutes=elements['minutes'],
                                       seconds=elements['seconds'])
 
-    return ParseError()
+    raise ParseError()


### PR DESCRIPTION
Parsing datetime raises ParseError if invalid.  Parsing durations should do the same.  
